### PR TITLE
Allow overriding the default strategy

### DIFF
--- a/lib/capistrano/tasks/nexus.rake
+++ b/lib/capistrano/tasks/nexus.rake
@@ -1,6 +1,6 @@
 namespace :nexus do
   def strategy
-    @strategy ||= Capistrano::Nexus.new(self, Capistrano::Nexus::DefaultStrategy)
+    @strategy ||= Capistrano::Nexus.new(self, fetch(:nexus_strategy, Capistrano::Nexus::DefaultStrategy))
   end
 
   desc 'Copy artifact contents to releases'


### PR DESCRIPTION
The original code does not allow to override the default strategy used by the rake tasks, because it forces the default strategy without fetching the current value.
This patch mimics the behavior of the Git tasks bundled with Capistrano, allowing overriding the default strategy.
