### PR TITLE
allow use of non-standard nexus port

### DIFF
--- a/lib/capistrano/nexus.rb
+++ b/lib/capistrano/nexus.rb
@@ -26,7 +26,7 @@ class Capistrano::Nexus < Capistrano::SCM
     def check
       begin
         uri = URI(artifact_url)
-        res = Net::HTTP.new(uri.host).request_head(uri.path)
+        res = Net::HTTP.new(uri.host, uri.port).request_head(uri.path)
         if res.code.to_i == 200
           true
         else


### PR DESCRIPTION
if not specified, 80 (http) or 443 (https) is used automatically and the custom port in URL is ignored